### PR TITLE
ENG-56569 Add components for Jenkins gem build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source :rubygems
 gem 'jasmine', '~> 1.1.0'
 gem 'headless'
 gem 'rake'
+gem 'geminabox'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source :rubygems
 
-gem 'jasmine'
+gem 'jasmine', '~> 1.1.0'
 gem 'headless'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,38 +1,45 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    childprocess (0.2.0)
-      ffi (~> 1.0.6)
-    diff-lcs (1.1.2)
-    ffi (1.0.9)
+    childprocess (0.5.7)
+      ffi (~> 1.0, >= 1.0.11)
+    diff-lcs (1.2.5)
+    ffi (1.9.10)
     headless (0.1.0)
-    jasmine (1.0.2.1)
-      json_pure (>= 1.4.3)
+    jasmine (1.1.2)
+      jasmine-core (>= 1.1.0)
       rack (>= 1.1)
       rspec (>= 1.3.1)
       selenium-webdriver (>= 0.1.3)
-    json_pure (1.5.3)
-    rack (1.3.2)
+    jasmine-core (2.3.4)
+    multi_json (1.11.2)
+    rack (1.6.4)
     rake (0.9.2)
-    rspec (2.6.0)
-      rspec-core (~> 2.6.0)
-      rspec-expectations (~> 2.6.0)
-      rspec-mocks (~> 2.6.0)
-    rspec-core (2.6.4)
-    rspec-expectations (2.6.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.6.0)
-    rubyzip (0.9.4)
-    selenium-webdriver (2.3.2)
-      childprocess (>= 0.1.9)
-      ffi (>= 1.0.7)
-      json_pure
-      rubyzip
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+    rubyzip (1.1.7)
+    selenium-webdriver (2.48.1)
+      childprocess (~> 0.5)
+      multi_json (~> 1.0)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
+    websocket (1.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   headless
-  jasmine
+  jasmine (~> 1.1.0)
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,21 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    builder (3.2.2)
     childprocess (0.5.7)
       ffi (~> 1.0, >= 1.0.11)
     diff-lcs (1.2.5)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
+    geminabox (0.12.4)
+      builder
+      faraday
+      httpclient (>= 2.2.7)
+      nesty
+      sinatra (>= 1.2.7)
     headless (0.1.0)
+    httpclient (2.6.0.1)
     jasmine (1.1.2)
       jasmine-core (>= 1.1.0)
       rack (>= 1.1)
@@ -13,7 +23,11 @@ GEM
       selenium-webdriver (>= 0.1.3)
     jasmine-core (2.3.4)
     multi_json (1.11.2)
+    multipart-post (2.0.0)
+    nesty (1.0.2)
     rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
     rake (0.9.2)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
@@ -34,12 +48,18 @@ GEM
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    tilt (2.0.1)
     websocket (1.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  geminabox
   headless
   jasmine (~> 1.1.0)
   rake

--- a/Rakefile
+++ b/Rakefile
@@ -2,3 +2,15 @@ require 'jasmine'
 load 'jasmine/tasks/jasmine.rake'
 
 task :default => "jasmine:ci"
+
+require "bundler/gem_tasks"
+
+module Bundler
+  class GemHelper
+    def rubygem_push(path)
+      gem_server_url = ENV['GEM_SERVER_URL']
+      sh("gem inabox '#{path}' --host #{gem_server_url}")
+      Bundler.ui.confirm "Pushed #{name} #{version} to #{gem_server_url}"
+    end
+  end
+end

--- a/backbone-support.gemspec
+++ b/backbone-support.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency('jasmine')
+  s.add_development_dependency('geminabox')
 end


### PR DESCRIPTION
Updated jasmine from 1.0.2.1 to next version up: 1.1.2. 1.0.2.1 contained deprecated methods that were breaking the gem build.
